### PR TITLE
Reverse dirs

### DIFF
--- a/lib/walk.js
+++ b/lib/walk.js
@@ -123,6 +123,7 @@
 
     if (flag !== Walker.NO_DESCEND) {
       me._wfnodegroups.directories.forEach(appendToDirs, dirs);
+      dirs.reverse();
       dirs.forEach(me._wJoinPath, me);
       me._wqueue.push(me._wq = dirs);
     }


### PR DESCRIPTION
i have done a reverse because the files has been read from the end because of the _wqueue (me._wqueue[me._wqueue.length-1]).