### PR TITLE
I gave support for Windows directory separators and changed the directory filtering method

### DIFF
--- a/lib/walk.js
+++ b/lib/walk.js
@@ -220,9 +220,18 @@
     // Stop directories that contain filter keywords
     // from continuing through the walk process
     exclude = me._wfilters.some(function (filter) {
-      if (me._wcurpath.match(filter)) {
+        /*
+        if (me._wcurpath.match(filter)) {
         return true;
-      }
+        }
+        */
+
+        var slice = me._wcurpath.substr(me._wcurpath.length - filter.length, me._wcurpath.length);
+
+        if (slice === filter) {
+            return true;
+        }
+
     });
 
     return exclude;

--- a/lib/walk.js
+++ b/lib/walk.js
@@ -40,6 +40,9 @@
     me._wfirstrun = true;
     me._wcurpath = pathname;
 
+	// If 'windows' directory separator is found, make sure the filter also use that one
+	me._convertPathSep();
+
     if (me._wsync) {
       //console.log('_walkSync');
       me._wWalk = me._wWalkSync;
@@ -68,6 +71,20 @@
   // Inherits must come before prototype additions
   util.inherits(Walker, EventEmitter);
 
+  Walker.prototype._convertPathSep = function() {
+	var me = this;
+	// If 'windows' directory separator is found, make sure the filter also use that one
+	if (path.sep === '\\') {
+		var re = new RegExp('/', 'g');
+
+		me._wfilters.forEach(function(filter, i){
+			me._wfilters[i] = me._wfilters[i].replace(re, '\\');
+		});
+
+		me._wcurpath = me._wcurpath.replace(re, '\\');
+	}
+  };
+
   Walker.prototype.NO_DESCEND = Walker.NO_DESCEND = NO_DESCEND;
 
   Walker.prototype._wLstatHandler = function (err, stat) {
@@ -94,7 +111,6 @@
     var statPath
       , me = this
       ;
-
 
     me._wcurfile = file;
     me._wCurFileCallback = cont;
@@ -220,16 +236,18 @@
     // Stop directories that contain filter keywords
     // from continuing through the walk process
     exclude = me._wfilters.some(function (filter) {
-        /*
-        if (me._wcurpath.match(filter)) {
-        return true;
-        }
-        */
+		var curDir = me._wcurpath;
 
-        var slice = me._wcurpath.substr(me._wcurpath.length - filter.length, me._wcurpath.length);
+		// Substract the 'filter' from the current path
+        var slice = curDir.substr(curDir.length - filter.length, curDir.length);
 
+		// Compare the filter string with the substracted slice
         if (slice === filter) {
-            return true;
+
+			// Make sure the filter starts with a directory separator
+			if (curDir.length === slice.length || curDir.substr(curDir.length - slice.length -1, 1) === path.sep) {
+				return true;
+			}
         }
 
     });
@@ -270,6 +288,7 @@
     }
     if (me._wq.length) {
       me._wcurpath = me._wq.pop();
+
       while (me._wq.length && me._wFilter()) {
         me._wcurpath = me._wq.pop();
       }
@@ -281,6 +300,7 @@
       return;
     }
     me._wqueue.length -= 1;
+
     if (me._wqueue.length) {
       me._wq = me._wqueue[me._wqueue.length - 1];
       return me._wNext();


### PR DESCRIPTION
Added the '_convertPathSep' method that will check the path.sep looking for a Windows-like directory separator,
and if positive, it will replace unix-like separators for "\\".

Changed the directory filtering logic: because the previous logic was made with a  string match, it not always worked as expected. I have made a string comparision that will check the directory hierarchy.

Walker can be called using paths (also in filters) with unix-like directory separators in Windows and it will work